### PR TITLE
Update sensors automatisch elk uur en definieer `unique_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,8 @@ Middels deze integratie wordt de huidige prijsinformatie van Frank Energie besch
 De waarden van de prijssensoren kunnen bijvoorbeeld gebruikt worden om apparatuur te schakelen op basis van de huidige energieprijs.
 
 ### Disclaimer
-Deze integratie is nog in een enorm vroege status. Prijsinformatie wordt automatisch gedownload, maar de waarden van sensoren worden niet automatisch ieder uur bijgewerkt. Voor nu is dit wel te realiseren middels bijvoorbeeld onderstaande automatisering:
-```
-alias: Update electriciteitsprijs
-description: 'Werk op het hele uur de huidige energieprijs bij'
-trigger:
-  - platform: time_pattern
-    minutes: '0'
-    seconds: '0'
-action:
-  - service: homeassistant.update_entity
-    target:
-      entity_id:
-        - sensor.current_electricity_price_all_in
-mode: single
-```
+Deze integratie is nog in een enorm vroege status.
+
 ## Installatie
 Plaats de map `frank_energie` uit de map `custom_components` binnen deze repo in de `custom_components` map van je Home Assistant installatie.
 

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 import asyncio
-from typing import List, Tuple
-import aiohttp
-from datetime import datetime, date, timedelta
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
 import logging
+from typing import Callable, List, Tuple
 
+import aiohttp
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
@@ -20,75 +21,92 @@ from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
     VOLUME_CUBIC_METERS,
 )
+from homeassistant.core import HassJob, HomeAssistant
+from homeassistant.helpers import event
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
+from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import utcnow
 
 ATTRIBUTION = "Data provided by Frank Energie"
-
-DOMAIN="frank_energie"
-
+DOMAIN = "frank_energie"
 DATA_URL = "https://frank-graphql-prod.graphcdn.app/"
-
 ICON = "mdi:currency-eur"
 
-SCAN_INTERVAL = timedelta(minutes=1)
 
-SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
-    SensorEntityDescription(
+@dataclass
+class FrankEnergieEntityDescription(SensorEntityDescription):
+    """Describes Frank Energie sensor entity."""
+    value_fn: Callable[[dict], StateType] = None
+
+
+SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
+    FrankEnergieEntityDescription(
         key="elec_markup",
         name="Current electricity price (All-in)",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
+        value_fn=lambda data: sum(data['elec']),
     ),
-    SensorEntityDescription(
+    FrankEnergieEntityDescription(
         key="elec_market",
         name="Current electricity market price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
+        value_fn=lambda data: data['elec'][0],
     ),
-    SensorEntityDescription(
+    FrankEnergieEntityDescription(
         key="elec_tax",
         name="Current electricity price including tax",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
+        value_fn=lambda data: data['elec'][0] + data['elec'][1],
     ),
-    SensorEntityDescription(
+    FrankEnergieEntityDescription(
         key="gas_markup",
         name="Current gas price (All-in)",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
+        value_fn=lambda data: sum(data['gas']),
     ),
-    SensorEntityDescription(
+    FrankEnergieEntityDescription(
         key="gas_market",
         name="Current gas market price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
+        value_fn=lambda data: data['gas'][0],
     ),
-    SensorEntityDescription(
+    FrankEnergieEntityDescription(
         key="gas_tax",
         name="Current gas price including tax",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
+        value_fn=lambda data: data['gas'][0] + data['gas'][1],
     ),
-    SensorEntityDescription(
+    FrankEnergieEntityDescription(
         key="gas_min",
         name="Lowest gas price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
+        value_fn=lambda data: min(data['today_gas']),
     ),
-    SensorEntityDescription(
+    FrankEnergieEntityDescription(
         key="gas_max",
         name="Highest gas price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
+        value_fn=lambda data: max(data['today_gas']),
     ),
-    SensorEntityDescription(
+    FrankEnergieEntityDescription(
         key="elec_min",
         name="Lowest energy price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
+        value_fn=lambda data: min(data['today_elec']),
     ),
-    SensorEntityDescription(
+    FrankEnergieEntityDescription(
         key="elec_max",
         name="Highest energy price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
+        value_fn=lambda data: max(data['today_elec']),
     ),
-    SensorEntityDescription(
+    FrankEnergieEntityDescription(
         key="elec_avg",
         name="Average electricity price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
+        value_fn=lambda data: round(sum(data['today_elec']) / len(data['today_elec']), 5)
     ),
 )
 
@@ -104,26 +122,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None) -> None:
     """Set up the Frank Energie sensors."""
     _LOGGER.debug("Setting up Frank")
 
     websession = async_get_clientsession(hass)
 
-    data = FrankEnergieData(websession)
-
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        # Name of the data. For logging purposes.
-        name="sensor",
-        update_method=data.async_fetch_data,
-        # Polling interval. Will only be polled if there are subscribers.
-        update_interval=timedelta(minutes=15),
-    )
+    coordinator = FrankEnergieCoordinator(hass, websession)
 
     entities = [
-        FrankEnergieSensor(coordinator, data, description)
+        FrankEnergieSensor(coordinator, description)
         for description in SENSOR_TYPES
         if description.key in config[CONF_DISPLAY_OPTIONS]
     ]
@@ -132,59 +141,101 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     async_add_entities(entities, True)
 
+
 class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Frank Energie sensor."""
 
     _attr_attribution = ATTRIBUTION
     _attr_icon = ICON
 
-    def __init__(self, coordinator, data, description: SensorEntityDescription) -> None:
+    def __init__(self, coordinator, description: FrankEnergieEntityDescription) -> None:
         """Initialize the sensor."""
-        self.entity_description = description
-        self.data = data
+        self.entity_description: FrankEnergieEntityDescription = description
+        self._attr_unique_id = f"frank_energie.{description.key}"
+
+        self._update_job = HassJob(self.async_schedule_update_ha_state)
+        self._unsub_update = None
+
         super().__init__(coordinator)
 
     async def async_update(self) -> None:
         """Get the latest data and updates the states."""
+        self._attr_native_value = self.entity_description.value_fn(self.coordinator.processed_data())
 
-        if self.data._elec_data and self.data._gas_data:
-            _LOGGER.debug("updating sensors")
+        # Cancel the currently scheduled event if there is any
+        if self._unsub_update:
+            self._unsub_update()
+            self._unsub_update = None
 
-            elec = self.get_current_hourprices(self.data._elec_data)
-            gas = self.get_current_hourprices(self.data._gas_data)
-            today_gas = self.get_hourprices(self.data._gas_data)
-            today_elec = self.get_hourprices(self.data._elec_data)
+        # Schedule the next update at exactly the next whole hour sharp
+        self._unsub_update = event.async_track_point_in_utc_time(
+            self.hass,
+            self._update_job,
+            utcnow().replace(minute=0, second=0, microsecond=0) + timedelta(hours=1),
+        )
 
-            sensor_type = self.entity_description.key
-            if sensor_type == "elec_markup":
-                self._attr_native_value = elec[0] + elec[1] + elec[2] + elec[3]
-            elif sensor_type == "elec_market":
-                self._attr_native_value = elec[0]
-            elif sensor_type == "elec_tax":
-                self._attr_native_value = elec[0] + elec[1]
-            elif sensor_type == "gas_markup":
-                self._attr_native_value = gas[0] + gas[1] + gas[2] + gas[3]
-            elif sensor_type == "gas_market":
-                self._attr_native_value = gas[0]
-            elif sensor_type == "gas_tax":
-                self._attr_native_value = gas[0] + gas[1]
-            elif sensor_type == "gas_max":
-                self._attr_native_value = max(today_gas)
-            elif sensor_type == "gas_min":
-                self._attr_native_value = min(today_gas)
-            elif sensor_type == "elec_max":
-                self._attr_native_value = max(today_elec)
-            elif sensor_type == "elec_min":
-                self._attr_native_value = min(today_elec)
-            elif sensor_type == "elec_avg":
-                self._attr_native_value = round(sum(today_elec) / len(today_elec), 5)
+
+class FrankEnergieCoordinator(DataUpdateCoordinator):
+    """Get the latest data and update the states."""
+
+    def __init__(self, hass: HomeAssistant, websession) -> None:
+        """Initialize the data object."""
+        self.hass = hass
+        self.websession = websession
+
+        logger = logging.getLogger(__name__)
+        super().__init__(
+            hass,
+            logger,
+            name="Frank Energie coordinator",
+            update_interval=timedelta(minutes=15),
+        )
+
+    async def _async_update_data(self) -> dict:
+        """Get the latest data from Frank Energie"""
+        self.logger.debug("Fetching Frank Energie data")
+
+        # We request data for today up until the day after tomorrow.
+        # This is to ensure we always request all available data.
+        today = date.today()
+        tomorrow = today + timedelta(days=2)
+        query_data = {
+            "query": """
+                query MarketPrices($startDate: Date!, $endDate: Date!) {
+                     marketPricesElectricity(startDate: $startDate, endDate: $endDate) { 
+                        from till marketPrice marketPriceTax sourcingMarkupPrice energyTaxPrice 
+                     } 
+                     marketPricesGas(startDate: $startDate, endDate: $endDate) { 
+                        from till marketPrice marketPriceTax sourcingMarkupPrice energyTaxPrice 
+                     } 
+                }
+            """,
+            "variables": {"startDate": str(today), "endDate": str(tomorrow)},
+            "operationName": "MarketPrices"
+        }
+        try:
+            resp = await self.websession.post(DATA_URL, json=query_data)
+
+            data = await resp.json()
+            return data['data']
+
+        except (asyncio.TimeoutError, aiohttp.ClientError, KeyError) as error:
+            raise UpdateFailed(f"Fetching energy data failed: {error}") from error
+
+    def processed_data(self):
+        return {
+            'elec': self.get_current_hourprices(self.data['marketPricesElectricity']),
+            'gas': self.get_current_hourprices(self.data['marketPricesGas']),
+            'today_elec': self.get_hourprices(self.data['marketPricesElectricity']),
+            'today_gas': self.get_hourprices(self.data['marketPricesGas'])
+        }
 
     def get_current_hourprices(self, hourprices) -> Tuple:
-        # hack to compare to datestring in json data        
+        # hack to compare to datestring in json data
         # additional hack to fix prices during DST
         hour_offset = 0
-        current_hour = datetime.utcnow() + timedelta(hours = hour_offset)
-        current_hour = str(current_hour.replace(microsecond=0,second=0,minute=0).isoformat()) + '.000Z'
+        current_hour = datetime.utcnow() + timedelta(hours=hour_offset)
+        current_hour = str(current_hour.replace(microsecond=0, second=0, minute=0).isoformat()) + '.000Z'
 
         for hour in hourprices:
             if hour['from'] == current_hour:
@@ -193,35 +244,7 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
     def get_hourprices(self, hourprices) -> List:
         today_prices = []
         for hour in hourprices:
-            today_prices.append((hour['marketPrice'] + hour['marketPriceTax'] + hour['sourcingMarkupPrice'] + hour['energyTaxPrice']))
+            today_prices.append(
+                (hour['marketPrice'] + hour['marketPriceTax'] + hour['sourcingMarkupPrice'] + hour['energyTaxPrice'])
+            )
         return today_prices
-
-class FrankEnergieData:
-    """Get the latest data and update the states."""
-
-    def __init__(self, websession) -> None:
-        """Initialize the data object."""
-        self.websession = websession
-        self._elec_data = None
-        self._gas_data = None
-        self._last_update = None
-
-    async def async_fetch_data(self) -> None:
-        """Get the latest data from Frank Energie"""
-        _LOGGER.debug("Fetching Frank Energie data")
-        # We request data for today up until the day after tomorrow. This is to ensure we always request all available data.
-        today = date.today()
-        tomorrow = today + timedelta(days = 2)
-        query_data = {	"query": "query MarketPrices($startDate: Date!, $endDate: Date!) { marketPricesElectricity(startDate: $startDate, endDate: $endDate) { from till marketPrice marketPriceTax sourcingMarkupPrice energyTaxPrice } marketPricesGas(startDate: $startDate, endDate: $endDate) { from till marketPrice marketPriceTax sourcingMarkupPrice energyTaxPrice } }",
-            "variables": { "startDate":str(today),"endDate":str(tomorrow) },
-            "operationName": "MarketPrices"
-        }
-        try:
-            resp = await self.websession.post(DATA_URL, json=query_data)
-        except (asyncio.TimeoutError, aiohttp.ClientError):
-            return
-
-        data = await resp.json()
-        self._elec_data = data['data']['marketPricesElectricity']
-        self._gas_data = data['data']['marketPricesGas']
-        self._last_update = datetime.now()


### PR DESCRIPTION
Ten eerste, bedankt voor het maken van deze custom component. Erg handig, en die GraphQL endpoint is ook mooi gevonden! Toen ik hem voor het eerst gebruikte dacht ik echter dat het niet werkte, omdat de sensoren niet updaten: ik had blijkbaar de readme niet goed gelezen.

Deze PR voegt daarom functionaliteit toe om de sensors automatisch elk uur te updaten, zodat het niet meer nodig is om dit met een losse automation te doen. (Fixes #10) Ook is er een `unique_id` attribuut toegevoegd zodat de naam/icon/entitiy_id aangepast kunnen worden in de UI van HA.

Verder nog een aantal dingen die ik heb veranderd: 

- De definities voor het bepalen van de waarde van een sensor naar de `SENSOR_TYPES` lijst verplaatst, zodat de definities van een sensor in één object zitten (Dit is vrij gebruikelijk om te doen in de HA code).
- `FrankEnergieData` is een subclass geworden van `DataUpdateCoordinator` zodat hij direct als coordinator gebruikt kan worden.
- Het processen van de data is naar de coordinator verplaats, zodat die verantwoordelijk is voor het aanleveren van alle de data.
- In `get_current_hourprices()` stond een comment over een hack om de tijdsvergelijking werkend te krijgen met DST, maar door de `from` en `till` datums te parsen naar een `datetime` object wordt de tijdzone altijd meegenomen bij het vergelijken met `now()` en is dit niet meer nodig.

Je moet maar kijken wat je er van vindt en of je het er mee eens bent, anders kan ik ze weer terugdraaien. 