### PR TITLE
Fix auto-update gas prijs sensors

### DIFF
--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import datetime, timedelta
 import logging
 from typing import Callable, List, Tuple
 
@@ -201,7 +201,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator):
 
         # We request data for today up until the day after tomorrow.
         # This is to ensure we always request all available data.
-        today = date.today()
+        today = datetime.utcnow().date()
         tomorrow = today + timedelta(days=1)
         day_after_tomorrow = today + timedelta(days=2)
 

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -160,7 +160,11 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
 
     async def async_update(self) -> None:
         """Get the latest data and updates the states."""
-        self._attr_native_value = self.entity_description.value_fn(self.coordinator.processed_data())
+        try:
+            self._attr_native_value = self.entity_description.value_fn(self.coordinator.processed_data())
+        except (TypeError, IndexError):
+            # No data available
+            self._attr_native_value = None
 
         # Cancel the currently scheduled event if there is any
         if self._unsub_update:

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 import logging
 from typing import Callable, List, Tuple
 
@@ -171,7 +171,7 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
         self._unsub_update = event.async_track_point_in_utc_time(
             self.hass,
             self._update_job,
-            utcnow().replace(minute=0, second=0, microsecond=0) + timedelta(hours=1),
+            utcnow().replace(minute=0, second=0) + timedelta(hours=1),
         )
 
 
@@ -232,7 +232,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator):
 
     def get_current_hourprices(self, hourprices) -> Tuple:
         for hour in hourprices:
-            if dt.parse_datetime(hour['from']) < dt.utcnow() < dt.parse_datetime(hour['till']):
+            if dt.parse_datetime(hour['from']) <= dt.utcnow() < dt.parse_datetime(hour['till']):
                 return hour['marketPrice'], hour['marketPriceTax'], hour['sourcingMarkupPrice'], hour['energyTaxPrice']
 
     def get_hourprices(self, hourprices) -> List:

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -199,10 +199,10 @@ class FrankEnergieCoordinator(DataUpdateCoordinator):
         """Get the latest data from Frank Energie"""
         self.logger.debug("Fetching Frank Energie data")
 
-        # We request data for today up until the day after tomorrow.
+        # We request data for yesterday up until the day after tomorrow.
         # This is to ensure we always request all available data.
-        today = date.today()
-        tomorrow = today + timedelta(days=2)
+        yesterday = date.today() - timedelta(days=1)
+        tomorrow = date.today() + timedelta(days=2)
         query_data = {
             "query": """
                 query MarketPrices($startDate: Date!, $endDate: Date!) {
@@ -214,7 +214,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator):
                      } 
                 }
             """,
-            "variables": {"startDate": str(today), "endDate": str(tomorrow)},
+            "variables": {"startDate": str(yesterday), "endDate": str(tomorrow)},
             "operationName": "MarketPrices"
         }
         try:


### PR DESCRIPTION
Blijkbaar zat er nog een bug in de code waardoor de gas-prijs gerelateerde sensors niet goed updaten, wat deze PR weer verhelpt door:

- Excepties af te vangen in `async_update()` zodat updates nog steeds worden gescheduled na een fout
- De uur-vergelijking inclusief te maken zodat een update om x:00:00.000 ook werkt (kleine kans dat dit fout gaat, maar toch)
- De prijs-data voor vandaag en morgen in twee losse requests te doen. Om een of andere reden kan de response voor gas prijzen max. 24 uur bevatten. Dit levert problemen op tijdens het wisselen van de dag, omdat er dan nog geen data is opgehaald voor net na 0:00. In twee losse requests krijgen we wel de juiste hoeveelheid data.