### PR TITLE
Voeg config flow toe voor setup via UI

### DIFF
--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -1,1 +1,42 @@
 """The Frank Energie component."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from .const import ATTRIBUTION, CONF_COORDINATOR, DOMAIN, FrankEnergieEntityDescription, ICON
+from .coordinator import FrankEnergieCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+PLATFORMS = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up the Frank Energie component from a config entry."""
+
+    # Initialise the coordinator and save it as domain-data
+    web_session_client = async_get_clientsession(hass)
+    frank_coordinator = FrankEnergieCoordinator(hass, web_session_client)
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {
+        CONF_COORDINATOR: frank_coordinator,
+    }
+
+    # Fetch initial data, so we have data when entities subscribe and set up the platform
+    await frank_coordinator.async_config_entry_first_refresh()
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -1,0 +1,28 @@
+"""Config flow for Picnic integration."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant import config_entries
+from .const import COMPONENT_TITLE, DOMAIN, UNIQUE_ID
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle the config flow for Frank Energie."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """Handle adding the config, no user input is needed."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=None
+            )
+
+        # Abort if we're adding a new config and the unique id is already in use, else create the entry
+        # For now it's only possible to add the Frank Energie integration once
+        await self.async_set_unique_id(UNIQUE_ID)
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(title=COMPONENT_TITLE, data={})

--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from homeassistant.components.sensor import (
+    SensorEntityDescription,
+)
+from homeassistant.const import (
+    CURRENCY_EURO,
+    ENERGY_KILO_WATT_HOUR,
+    VOLUME_CUBIC_METERS,
+)
+from homeassistant.helpers.typing import StateType
+
+ATTRIBUTION = "Data provided by Frank Energie"
+DOMAIN = "frank_energie"
+DATA_URL = "https://frank-graphql-prod.graphcdn.app/"
+ICON = "mdi:currency-eur"
+UNIQUE_ID = f"{DOMAIN}_component"
+COMPONENT_TITLE = "Frank Energie"
+
+CONF_COORDINATOR = "coordinator"
+
+
+@dataclass
+class FrankEnergieEntityDescription(SensorEntityDescription):
+    """Describes Frank Energie sensor entity."""
+    value_fn: Callable[[dict], StateType] = None
+
+
+SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
+    FrankEnergieEntityDescription(
+        key="elec_markup",
+        name="Current electricity price (All-in)",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
+        value_fn=lambda data: sum(data['elec']),
+    ),
+    FrankEnergieEntityDescription(
+        key="elec_market",
+        name="Current electricity market price",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
+        value_fn=lambda data: data['elec'][0],
+    ),
+    FrankEnergieEntityDescription(
+        key="elec_tax",
+        name="Current electricity price including tax",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
+        value_fn=lambda data: data['elec'][0] + data['elec'][1],
+    ),
+    FrankEnergieEntityDescription(
+        key="gas_markup",
+        name="Current gas price (All-in)",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
+        value_fn=lambda data: sum(data['gas']),
+    ),
+    FrankEnergieEntityDescription(
+        key="gas_market",
+        name="Current gas market price",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
+        value_fn=lambda data: data['gas'][0],
+    ),
+    FrankEnergieEntityDescription(
+        key="gas_tax",
+        name="Current gas price including tax",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
+        value_fn=lambda data: data['gas'][0] + data['gas'][1],
+    ),
+    FrankEnergieEntityDescription(
+        key="gas_min",
+        name="Lowest gas price today",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
+        value_fn=lambda data: min(data['today_gas']),
+    ),
+    FrankEnergieEntityDescription(
+        key="gas_max",
+        name="Highest gas price today",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
+        value_fn=lambda data: max(data['today_gas']),
+    ),
+    FrankEnergieEntityDescription(
+        key="elec_min",
+        name="Lowest energy price today",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
+        value_fn=lambda data: min(data['today_elec']),
+    ),
+    FrankEnergieEntityDescription(
+        key="elec_max",
+        name="Highest energy price today",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
+        value_fn=lambda data: max(data['today_elec']),
+    ),
+    FrankEnergieEntityDescription(
+        key="elec_avg",
+        name="Average electricity price today",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
+        value_fn=lambda data: round(sum(data['today_elec']) / len(data['today_elec']), 5)
+    ),
+)

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+import logging
+from typing import List, Tuple
+
+import aiohttp
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt
+from .const import DATA_URL
+
+
+class FrankEnergieCoordinator(DataUpdateCoordinator):
+    """Get the latest data and update the states."""
+
+    def __init__(self, hass: HomeAssistant, websession) -> None:
+        """Initialize the data object."""
+        self.hass = hass
+        self.websession = websession
+
+        logger = logging.getLogger(__name__)
+        super().__init__(
+            hass,
+            logger,
+            name="Frank Energie coordinator",
+            update_interval=timedelta(minutes=15),
+        )
+
+    async def _async_update_data(self) -> dict:
+        """Get the latest data from Frank Energie"""
+        self.logger.debug("Fetching Frank Energie data")
+
+        # We request data for today up until the day after tomorrow.
+        # This is to ensure we always request all available data.
+        today = datetime.utcnow().date()
+        tomorrow = today + timedelta(days=1)
+        day_after_tomorrow = today + timedelta(days=2)
+
+        # Fetch data for today and tomorrow separately,
+        # because the gas prices response only contains data for the first day of the query
+        data_today = await self._run_graphql_query(today, tomorrow)
+        data_tomorrow = await self._run_graphql_query(tomorrow, day_after_tomorrow)
+
+        return {
+            'marketPricesElectricity': data_today['marketPricesElectricity'] + data_tomorrow['marketPricesElectricity'],
+            'marketPricesGas': data_today['marketPricesGas'] + data_tomorrow['marketPricesGas'],
+        }
+
+    async def _run_graphql_query(self, start_date, end_date):
+        query_data = {
+            "query": """
+                query MarketPrices($startDate: Date!, $endDate: Date!) {
+                     marketPricesElectricity(startDate: $startDate, endDate: $endDate) { 
+                        from till marketPrice marketPriceTax sourcingMarkupPrice energyTaxPrice 
+                     } 
+                     marketPricesGas(startDate: $startDate, endDate: $endDate) { 
+                        from till marketPrice marketPriceTax sourcingMarkupPrice energyTaxPrice 
+                     } 
+                }
+            """,
+            "variables": {"startDate": str(start_date), "endDate": str(end_date)},
+            "operationName": "MarketPrices"
+        }
+        try:
+            resp = await self.websession.post(DATA_URL, json=query_data)
+
+            data = await resp.json()
+            return data['data']
+
+        except (asyncio.TimeoutError, aiohttp.ClientError, KeyError) as error:
+            raise UpdateFailed(f"Fetching energy data failed: {error}") from error
+
+    def processed_data(self):
+        return {
+            'elec': self.get_current_hourprices(self.data['marketPricesElectricity']),
+            'gas': self.get_current_hourprices(self.data['marketPricesGas']),
+            'today_elec': self.get_hourprices(self.data['marketPricesElectricity']),
+            'today_gas': self.get_hourprices(self.data['marketPricesGas'])
+        }
+
+    def get_current_hourprices(self, hourprices) -> Tuple:
+        for hour in hourprices:
+            if dt.parse_datetime(hour['from']) <= dt.utcnow() < dt.parse_datetime(hour['till']):
+                return hour['marketPrice'], hour['marketPriceTax'], hour['sourcingMarkupPrice'], hour['energyTaxPrice']
+
+    def get_hourprices(self, hourprices) -> List:
+        today_prices = []
+        for hour in hourprices:
+            today_prices.append(
+                (hour['marketPrice'] + hour['marketPriceTax'] + hour['sourcingMarkupPrice'] + hour['energyTaxPrice'])
+            )
+        return today_prices

--- a/custom_components/frank_energie/manifest.json
+++ b/custom_components/frank_energie/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "frank_energie",
   "name": "Frank Energie",
+  "config_flow": true,
   "codeowners": ["@bajansen"],
   "documentation": "https://github.com/bajansen/home-assistant-frank_energie",
   "issue_tracker": "https://github.com/bajansen/home-assistant-frank_energie/issues",

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -1,145 +1,35 @@
 """Frank Energie current electricity and gas price information service."""
 from __future__ import annotations
 
-import asyncio
-from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
-from typing import Callable, List, Tuple
 
-import aiohttp
-import voluptuous as vol
-
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA,
-    SensorEntity,
-    SensorEntityDescription,
-)
-from homeassistant.const import (
-    CONF_DISPLAY_OPTIONS,
-    CURRENCY_EURO,
-    ENERGY_KILO_WATT_HOUR,
-    VOLUME_CUBIC_METERS,
-)
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HassJob, HomeAssistant
 from homeassistant.helpers import event
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import StateType
-from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt, utcnow
-
-ATTRIBUTION = "Data provided by Frank Energie"
-DOMAIN = "frank_energie"
-DATA_URL = "https://frank-graphql-prod.graphcdn.app/"
-ICON = "mdi:currency-eur"
-
-
-@dataclass
-class FrankEnergieEntityDescription(SensorEntityDescription):
-    """Describes Frank Energie sensor entity."""
-    value_fn: Callable[[dict], StateType] = None
-
-
-SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
-    FrankEnergieEntityDescription(
-        key="elec_markup",
-        name="Current electricity price (All-in)",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: sum(data['elec']),
-    ),
-    FrankEnergieEntityDescription(
-        key="elec_market",
-        name="Current electricity market price",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: data['elec'][0],
-    ),
-    FrankEnergieEntityDescription(
-        key="elec_tax",
-        name="Current electricity price including tax",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: data['elec'][0] + data['elec'][1],
-    ),
-    FrankEnergieEntityDescription(
-        key="gas_markup",
-        name="Current gas price (All-in)",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: sum(data['gas']),
-    ),
-    FrankEnergieEntityDescription(
-        key="gas_market",
-        name="Current gas market price",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: data['gas'][0],
-    ),
-    FrankEnergieEntityDescription(
-        key="gas_tax",
-        name="Current gas price including tax",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: data['gas'][0] + data['gas'][1],
-    ),
-    FrankEnergieEntityDescription(
-        key="gas_min",
-        name="Lowest gas price today",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: min(data['today_gas']),
-    ),
-    FrankEnergieEntityDescription(
-        key="gas_max",
-        name="Highest gas price today",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: max(data['today_gas']),
-    ),
-    FrankEnergieEntityDescription(
-        key="elec_min",
-        name="Lowest energy price today",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: min(data['today_elec']),
-    ),
-    FrankEnergieEntityDescription(
-        key="elec_max",
-        name="Highest energy price today",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: max(data['today_elec']),
-    ),
-    FrankEnergieEntityDescription(
-        key="elec_avg",
-        name="Average electricity price today",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: round(sum(data['today_elec']) / len(data['today_elec']), 5)
-    ),
-)
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import utcnow
+from .const import ATTRIBUTION, CONF_COORDINATOR, DOMAIN, FrankEnergieEntityDescription, ICON, SENSOR_TYPES
+from .coordinator import FrankEnergieCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-OPTION_KEYS = [desc.key for desc in SENSOR_TYPES]
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_DISPLAY_OPTIONS, default=[]): vol.All(
-            cv.ensure_list, [vol.In(OPTION_KEYS)]
-        ),
-    }
-)
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Frank Energie sensor entries."""
+    frank_coordinator = hass.data[DOMAIN][config_entry.entry_id][CONF_COORDINATOR]
 
-
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None) -> None:
-    """Set up the Frank Energie sensors."""
-    _LOGGER.debug("Setting up Frank Energie component")
-
-    websession = async_get_clientsession(hass)
-
-    coordinator = FrankEnergieCoordinator(hass, websession)
-
-    entities = [
-        FrankEnergieSensor(coordinator, description)
+    # Add an entity for each sensor type
+    async_add_entities([
+        FrankEnergieSensor(frank_coordinator, description)
         for description in SENSOR_TYPES
-        if description.key in config[CONF_DISPLAY_OPTIONS]
-    ]
-
-    await coordinator.async_config_entry_first_refresh()
-
-    async_add_entities(entities, True)
+    ], True)
 
 
 class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
@@ -177,85 +67,3 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
             self._update_job,
             utcnow().replace(minute=0, second=0) + timedelta(hours=1),
         )
-
-
-class FrankEnergieCoordinator(DataUpdateCoordinator):
-    """Get the latest data and update the states."""
-
-    def __init__(self, hass: HomeAssistant, websession) -> None:
-        """Initialize the data object."""
-        self.hass = hass
-        self.websession = websession
-
-        logger = logging.getLogger(__name__)
-        super().__init__(
-            hass,
-            logger,
-            name="Frank Energie coordinator",
-            update_interval=timedelta(minutes=15),
-        )
-
-    async def _async_update_data(self) -> dict:
-        """Get the latest data from Frank Energie"""
-        self.logger.debug("Fetching Frank Energie data")
-
-        # We request data for today up until the day after tomorrow.
-        # This is to ensure we always request all available data.
-        today = datetime.utcnow().date()
-        tomorrow = today + timedelta(days=1)
-        day_after_tomorrow = today + timedelta(days=2)
-
-        # Fetch data for today and tomorrow separately,
-        # because the gas prices response only contains data for the first day of the query
-        data_today = await self._run_graphql_query(today, tomorrow)
-        data_tomorrow = await self._run_graphql_query(tomorrow, day_after_tomorrow)
-
-        return {
-            'marketPricesElectricity': data_today['marketPricesElectricity'] + data_tomorrow['marketPricesElectricity'],
-            'marketPricesGas': data_today['marketPricesGas'] + data_tomorrow['marketPricesGas'],
-        }
-
-    async def _run_graphql_query(self, start_date, end_date):
-        query_data = {
-            "query": """
-                query MarketPrices($startDate: Date!, $endDate: Date!) {
-                     marketPricesElectricity(startDate: $startDate, endDate: $endDate) { 
-                        from till marketPrice marketPriceTax sourcingMarkupPrice energyTaxPrice 
-                     } 
-                     marketPricesGas(startDate: $startDate, endDate: $endDate) { 
-                        from till marketPrice marketPriceTax sourcingMarkupPrice energyTaxPrice 
-                     } 
-                }
-            """,
-            "variables": {"startDate": str(start_date), "endDate": str(end_date)},
-            "operationName": "MarketPrices"
-        }
-        try:
-            resp = await self.websession.post(DATA_URL, json=query_data)
-
-            data = await resp.json()
-            return data['data']
-
-        except (asyncio.TimeoutError, aiohttp.ClientError, KeyError) as error:
-            raise UpdateFailed(f"Fetching energy data failed: {error}") from error
-
-    def processed_data(self):
-        return {
-            'elec': self.get_current_hourprices(self.data['marketPricesElectricity']),
-            'gas': self.get_current_hourprices(self.data['marketPricesGas']),
-            'today_elec': self.get_hourprices(self.data['marketPricesElectricity']),
-            'today_gas': self.get_hourprices(self.data['marketPricesGas'])
-        }
-
-    def get_current_hourprices(self, hourprices) -> Tuple:
-        for hour in hourprices:
-            if dt.parse_datetime(hour['from']) <= dt.utcnow() < dt.parse_datetime(hour['till']):
-                return hour['marketPrice'], hour['marketPriceTax'], hour['sourcingMarkupPrice'], hour['energyTaxPrice']
-
-    def get_hourprices(self, hourprices) -> List:
-        today_prices = []
-        for hour in hourprices:
-            today_prices.append(
-                (hour['marketPrice'] + hour['marketPriceTax'] + hour['sourcingMarkupPrice'] + hour['energyTaxPrice'])
-            )
-        return today_prices

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -1,0 +1,9 @@
+{
+  "config": {
+    "step": {
+      "user": {
+          "description": "No authentication or configuration needed."
+      }
+    }
+  }
+}

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -1,0 +1,9 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "description": "No authentication or configuration needed."
+            }
+        }
+    }
+}

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -1,0 +1,9 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "description": "Geen authenticatie of configuratie nodig."
+            }
+        }
+    }
+}


### PR DESCRIPTION
Deze PR voegt een zeer simpele config flow toe waarmee het mogelijk is om de Frank Energie integratie via de UI te configureren. Er wordt nog niet om user input gevraagd, maar in de toekomst kunnen we de config flow bijv. wel gebruiken om een gebruiker in te laten loggen met z'n Frank gegevens, om zo dezelfde prijzen die in de app getoond worden in HA te krijgen. (Op dit moment lijkt de gasprijs van de publieke prijzen API die nu gebruikt wordt nl. niet te kloppen...)

Veranderingen:
- Split `sensor.py` in specifieke betanden voor constanten, de data coordinator en de sensor zelf.
- Voeg de simpele config flow toe