### PR TITLE
Maak ophalen en verwerken van data flexibeler/minder vatbaar voor verbindingsproblemen

### DIFF
--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import Any, Callable
 
+from .price_data import PriceData
 from homeassistant.components.sensor import SensorEntityDescription
 
 from homeassistant.const import (
@@ -22,123 +23,127 @@ COMPONENT_TITLE = "Frank Energie"
 CONF_COORDINATOR = "coordinator"
 ATTR_TIME = "from_time"
 
+DATA_ELECTRICITY = 'electricity'
+DATA_GAS = 'gas'
+
+
 @dataclass
 class FrankEnergieEntityDescription(SensorEntityDescription):
     """Describes Frank Energie sensor entity."""
-    value_fn: Callable[[dict], StateType] = None
-    attr_fn: Callable[[dict[str, Any]], dict[str, StateType]] = lambda _: {}
+    value_fn: Callable[[PriceData], StateType] = None
+    attr_fn: Callable[[PriceData], dict[str, StateType]] = lambda _: {}
 
 SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
     FrankEnergieEntityDescription(
         key="elec_markup",
         name="Current electricity price (All-in)",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: sum(data['elec']),
+        value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.total,
     ),
     FrankEnergieEntityDescription(
         key="elec_market",
         name="Current electricity market price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: data['elec'][0],
+        value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.market_price,
     ),
     FrankEnergieEntityDescription(
         key="elec_tax",
         name="Current electricity price including tax",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: data['elec'][0] + data['elec'][1],
+        value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.market_price_with_tax,
     ),
     FrankEnergieEntityDescription(
         key="elec_tax_vat",
         name="Current electricity VAT price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: data['elec'][1],
+        value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.market_price_tax,
         entity_registry_enabled_default=False,
     ),
     FrankEnergieEntityDescription(
         key="elec_sourcing",
         name="Current electricity sourcing markup",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: data['elec'][2],
+        value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.sourcing_markup_price,
         entity_registry_enabled_default=False,
     ),
     FrankEnergieEntityDescription(
         key="elec_tax_only",
         name="Current electricity tax only",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: data['elec'][3],
+        value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.energy_tax_price,
         entity_registry_enabled_default=False,
     ),
     FrankEnergieEntityDescription(
         key="gas_markup",
         name="Current gas price (All-in)",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: sum(data['gas']),
+        value_fn=lambda data: data[DATA_GAS].current_hour.total,
     ),
     FrankEnergieEntityDescription(
         key="gas_market",
         name="Current gas market price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: data['gas'][0],
+        value_fn=lambda data: data[DATA_GAS].current_hour.market_price,
     ),
     FrankEnergieEntityDescription(
         key="gas_tax",
         name="Current gas price including tax",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: data['gas'][0] + data['gas'][1],
+        value_fn=lambda data: data[DATA_GAS].current_hour.market_price_with_tax,
     ),
     FrankEnergieEntityDescription(
         key="gas_tax_vat",
         name="Current gas VAT price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: data['gas'][1],
+        value_fn=lambda data: data[DATA_GAS].current_hour.market_price_tax,
         entity_registry_enabled_default=False,
     ),
     FrankEnergieEntityDescription(
         key="gas_sourcing",
         name="Current gas sourcing price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: data['gas'][2],
+        value_fn=lambda data: data[DATA_GAS].current_hour.sourcing_markup_price,
         entity_registry_enabled_default=False,
     ),
     FrankEnergieEntityDescription(
         key="gas_tax_only",
         name="Current gas tax only",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: data['gas'][3],
+        value_fn=lambda data: data[DATA_GAS].current_hour.energy_tax_price,
         entity_registry_enabled_default=False,
     ),
     FrankEnergieEntityDescription(
         key="gas_min",
         name="Lowest gas price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: min(data['today_gas'].values()),
-        attr_fn=lambda data: {ATTR_TIME: min(data['today_gas'],key=data['today_gas'].get)},
+        value_fn=lambda data: data[DATA_GAS].today_min.total,
+        attr_fn=lambda data: {ATTR_TIME: data[DATA_GAS].today_min.date_from},
     ),
     FrankEnergieEntityDescription(
         key="gas_max",
         name="Highest gas price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
-        value_fn=lambda data: max(data['today_gas'].values()),
-        attr_fn=lambda data: {ATTR_TIME: max(data['today_gas'],key=data['today_gas'].get)},
+        value_fn=lambda data: data[DATA_GAS].today_max.total,
+        attr_fn=lambda data: {ATTR_TIME: data[DATA_GAS].today_max.date_from},
     ),
     FrankEnergieEntityDescription(
         key="elec_min",
         name="Lowest energy price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: min(data['today_elec'].values()),
-        attr_fn=lambda data: {ATTR_TIME: min(data['today_elec'],key=data['today_elec'].get)},
+        value_fn=lambda data: data[DATA_ELECTRICITY].today_min.total,
+        attr_fn=lambda data: {ATTR_TIME: data[DATA_ELECTRICITY].today_min.date_from},
     ),
     FrankEnergieEntityDescription(
         key="elec_max",
         name="Highest energy price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: max(data['today_elec'].values()),
-        attr_fn=lambda data: {ATTR_TIME: max(data['today_elec'],key=data['today_elec'].get)},
+        value_fn=lambda data: data[DATA_ELECTRICITY].today_max.total,
+        attr_fn=lambda data: {ATTR_TIME: data[DATA_ELECTRICITY].today_max.date_from},
     ),
     FrankEnergieEntityDescription(
         key="elec_avg",
         name="Average electricity price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
-        value_fn=lambda data: round(sum(data['today_elec'].values()) / len(data['today_elec'].values()), 5)
+        value_fn=lambda data: data[DATA_ELECTRICITY].today_avg
     ),
 )

--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -30,8 +30,8 @@ DATA_GAS = 'gas'
 @dataclass
 class FrankEnergieEntityDescription(SensorEntityDescription):
     """Describes Frank Energie sensor entity."""
-    value_fn: Callable[[PriceData], StateType] = None
-    attr_fn: Callable[[PriceData], dict[str, StateType]] = lambda _: {}
+    value_fn: Callable[[dict[PriceData]], StateType] = None
+    attr_fn: Callable[[dict[PriceData]], dict[str, StateType]] = lambda _: {}
 
 SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
     FrankEnergieEntityDescription(

--- a/custom_components/frank_energie/price_data.py
+++ b/custom_components/frank_energie/price_data.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+
+from homeassistant.util import dt
+
+
+class Price:
+    """ Price data for one hour"""
+
+    date_from: datetime
+    date_till: datetime
+    market_price: float
+    market_price_tax: float
+    sourcing_markup_rice: float
+    energy_tax_price: float
+
+    def __init__(self, data: dict):
+        self.date_from = dt.parse_datetime(data['from'])
+        self.date_till = dt.parse_datetime(data['till'])
+
+        self.market_price = data['marketPrice']
+        self.market_price_tax = data['marketPriceTax']
+        self.sourcing_markup_price = data['sourcingMarkupPrice']
+        self.energy_tax_price = data['energyTaxPrice']
+
+    @property
+    def for_now(self):
+        """ Whether this price entry is for the current hour. """
+        return self.date_from <= dt.utcnow() < self.date_till
+
+    @property
+    def for_future(self):
+        """ Whether this price entry is for and hour after the current one. """
+        return self.date_from.hour > dt.utcnow().hour
+
+    @property
+    def for_today(self):
+        """ Whether this price entry is for the current day. """
+        day_start = dt.utcnow().replace(hour=0, minute=0, second=0)
+        day_end = dt.utcnow().replace(hour=23, minute=59, second=59)
+        return self.date_from > day_start and self.date_till < day_end
+
+    @property
+    def market_price_with_tax(self):
+        return self.market_price + self.market_price_tax
+
+    @property
+    def total(self):
+        return self.market_price + self.market_price_tax + self.sourcing_markup_price + self.energy_tax_price
+
+    @property
+    def hour(self):
+        return self.date_from.astimezone()
+
+class PriceData:
+
+    def __init__(self, price_data: list[Price]):
+        self.price_data = [Price(price) for price in price_data]
+
+    @property
+    def today(self) -> list[Price]:
+        return [hour for hour in self.price_data if hour.for_today]
+
+    @property
+    def current_hour(self) -> Price:
+        """ Price that's currently applicable. """
+        return [hour for hour in self.price_data if hour.for_now][0]
+
+    @property
+    def today_min(self) -> Price:
+        return min([hour for hour in self.today], key=lambda hour: hour.total)
+
+    @property
+    def today_max(self) -> Price:
+        return max([hour for hour in self.today], key=lambda hour: hour.total)
+
+    @property
+    def today_avg(self) -> float:
+        return round(sum(hour.total for hour in self.today) / len(self.today), 5)
+
+    def get_future_prices(self):
+        """ Prices for hours after the current one. """
+        return [hour for hour in self.price_data if hour.for_future]

--- a/custom_components/frank_energie/price_data.py
+++ b/custom_components/frank_energie/price_data.py
@@ -14,8 +14,8 @@ class Price:
     energy_tax_price: float
 
     def __init__(self, data: dict):
-        self.date_from = dt.parse_datetime(data['from'])
-        self.date_till = dt.parse_datetime(data['till'])
+        self.date_from = dt.as_local(dt.parse_datetime(data['from']))
+        self.date_till = dt.as_local(dt.parse_datetime(data['till']))
 
         self.market_price = data['marketPrice']
         self.market_price_tax = data['marketPriceTax']
@@ -41,20 +41,22 @@ class Price:
 
     @property
     def market_price_with_tax(self):
-        return self.market_price + self.market_price_tax
+        return round(self.market_price + self.market_price_tax, 4)
 
     @property
     def total(self):
-        return self.market_price + self.market_price_tax + self.sourcing_markup_price + self.energy_tax_price
+        return round(self.market_price + self.market_price_tax + self.sourcing_markup_price + self.energy_tax_price, 4)
 
-    @property
-    def hour(self):
-        return self.date_from.astimezone()
 
 class PriceData:
+    price_data: list[Price]
 
-    def __init__(self, price_data: list[Price]):
+    def __init__(self, price_data: list[dict]):
         self.price_data = [Price(price) for price in price_data]
+
+    @property
+    def all(self):
+        return self.price_data
 
     @property
     def today(self) -> list[Price]:

--- a/custom_components/frank_energie/price_data.py
+++ b/custom_components/frank_energie/price_data.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from homeassistant.util import dt
 
@@ -25,19 +25,19 @@ class Price:
     @property
     def for_now(self):
         """ Whether this price entry is for the current hour. """
-        return self.date_from <= dt.utcnow() < self.date_till
+        return self.date_from <= dt.now() < self.date_till
 
     @property
     def for_future(self):
         """ Whether this price entry is for and hour after the current one. """
-        return self.date_from.hour > dt.utcnow().hour
+        return self.date_from.hour > dt.now().hour
 
     @property
     def for_today(self):
         """ Whether this price entry is for the current day. """
-        day_start = dt.utcnow().replace(hour=0, minute=0, second=0)
-        day_end = dt.utcnow().replace(hour=23, minute=59, second=59)
-        return self.date_from > day_start and self.date_till < day_end
+        day_start = dt.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        day_end = day_start + timedelta(days=1)
+        return self.date_from >= day_start and self.date_till <= day_end
 
     @property
     def market_price_with_tax(self):

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
 
     # Add an entity for each sensor type
     async_add_entities([
-        FrankEnergieSensor(frank_coordinator, description)
+        FrankEnergieSensor(hass, frank_coordinator, description)
         for description in SENSOR_TYPES
     ], True)
 
@@ -45,8 +45,9 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, coordinator: FrankEnergieCoordinator, description: FrankEnergieEntityDescription) -> None:
+    def __init__(self, hass: HomeAssistant, coordinator: FrankEnergieCoordinator, description: FrankEnergieEntityDescription) -> None:
         """Initialize the sensor."""
+        self.hass = hass
         self.entity_description: FrankEnergieEntityDescription = description
         self._attr_unique_id = f"frank_energie.{description.key}"
 

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorEntity,
@@ -57,7 +58,7 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
     async def async_update(self) -> None:
         """Get the latest data and updates the states."""
         try:
-            self._attr_native_value = self.entity_description.value_fn(self.coordinator.processed_data())
+            self._attr_native_value = self.entity_description.value_fn(self.coordinator.data)
         except (TypeError, IndexError):
             # No data available
             self._attr_native_value = None
@@ -77,4 +78,4 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
-        return self.entity_description.attr_fn(self.coordinator.processed_data())
+        return self.entity_description.attr_fn(self.coordinator.data)


### PR DESCRIPTION
Ik zag dat het probleem met het ophalen van de data van de volgende dag al was opgelost. Volgens de comments was dit echter een beetje 'smelly', dus ik heb bij deze geprobeerd het minder 'smelly' te maken 🙂.
Wijzigingen:

- Constanten toegevoegd zodat de coordinator data een expliciete structuur heeft.
- `_run_graphql_query` returned altijd een `dict`, zodat we met `.get()` de data kunnen ophalen met als default een lege lijst.
- `Price` en `PriceData` classes toegevoegd waarbij een `Price` object de data voor een uur bevat incl. wat helper functies, en `PriceData` een list van `Price`s bevat, incl. wat helper functies.
- Als een update fout gaat en we hebben nog genoeg data for iig het uur na het huidige uur, dan wordt de `UpdateFailed` exceptie niet gegooid en alleen een warning gelogd zodat de sensors nog de data laten zien die we al hadden opgehaald.
- De lambda's in `const.py` zijn aangepast zodat ze de `PriceData` gebruiken.

De huidige implementatie bevat wel een breaking change: voor de sensors die 'today' in de naam hebben wordt ook echt allen data van vandaag gebruikt. Dit kan ik makkelijk wijzigen indien niet gewenst, maar daar staat al wel een poosje een issue voor open.

Ik wil het zelf nog een paar dagen laten draaien om het goed te testen, maar een review wordt alvast op prijs gesteld 🙂.