### PR TITLE
Forceer update van sensor zodat nieuwe update wordt gepland

### DIFF
--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
 
     # Add an entity for each sensor type
     async_add_entities([
-        FrankEnergieSensor(hass, frank_coordinator, description)
+        FrankEnergieSensor(frank_coordinator, description)
         for description in SENSOR_TYPES
     ], True)
 
@@ -45,9 +45,8 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, hass: HomeAssistant, coordinator: FrankEnergieCoordinator, description: FrankEnergieEntityDescription) -> None:
+    def __init__(self, coordinator: FrankEnergieCoordinator, description: FrankEnergieEntityDescription) -> None:
         """Initialize the sensor."""
-        self.hass = hass
         self.entity_description: FrankEnergieEntityDescription = description
         self._attr_unique_id = f"frank_energie.{description.key}"
 
@@ -60,7 +59,7 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
         """Get the latest data and updates the states."""
         try:
             self._attr_native_value = self.entity_description.value_fn(self.coordinator.data)
-        except (TypeError, IndexError):
+        except (TypeError, IndexError, ValueError):
             # No data available
             self._attr_native_value = None
 
@@ -83,7 +82,7 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
         if self.hass is None:
             return
 
-        self.async_schedule_update_ha_state()
+        self.async_schedule_update_ha_state(True)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:


### PR DESCRIPTION
PR #38 heeft de automatische updates van de sensoren kapot gemaakt. Blijkbaar deed HASS dat standaard wanneer `async_schedule_update_ha_state` als `HassJob` wordt uitgevoerd. Dit is nu opgelost door `self.async_schedule_update_ha_state(True)` aan te roepen, waarbij `True` de update forceert.

Fixes #44.