### PR TITLE
Voeg uur-prijs attribuut toe met alle bekende prijzen

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,12 @@ Vervolgens kunnen sensoren per stuk worden uitgeschakeld of verborgen indien gew
 #### Let op!
 
 Indien je deze plugin al gebruikte en hebt ingesteld via `configuration.yaml` dien je deze instellingen te verwijderen en Frank Energie opnieuw in te stellen middels de config flow zoals hierboven beschreven.
+
+### Gebruik
+
+Een aantal sensors hebben een `prices` attribuut die alle bekende prijzen bevat. Dit kan worden gebruikt om zelf met een template nieuwe sensors te maken.
+
+Voorbeeld om de hoogst bekende prijs na het huidige uur te bepalen:
+```
+{{ state_attr('sensor.current_electricity_price_all_in', 'prices') | selectattr('from', 'gt', now()) | max(attribute='price') }}
+```

--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -31,7 +31,7 @@ DATA_GAS = 'gas'
 class FrankEnergieEntityDescription(SensorEntityDescription):
     """Describes Frank Energie sensor entity."""
     value_fn: Callable[[dict[PriceData]], StateType] = None
-    attr_fn: Callable[[dict[PriceData]], dict[str, StateType]] = lambda _: {}
+    attr_fn: Callable[[dict[PriceData]], dict[str, StateType | list]] = lambda _: {}
 
 
 SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
@@ -40,18 +40,21 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current electricity price (All-in)",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.total,
+        attr_fn=lambda data: {'prices': data[DATA_ELECTRICITY].asdict('total')},
     ),
     FrankEnergieEntityDescription(
         key="elec_market",
         name="Current electricity market price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.market_price,
+        attr_fn=lambda data: {'prices': data[DATA_ELECTRICITY].asdict('market_price')},
     ),
     FrankEnergieEntityDescription(
         key="elec_tax",
         name="Current electricity price including tax",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.market_price_with_tax,
+        attr_fn=lambda data: {'prices': data[DATA_ELECTRICITY].asdict('market_price_with_tax')},
     ),
     FrankEnergieEntityDescription(
         key="elec_tax_vat",
@@ -79,18 +82,21 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current gas price (All-in)",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
         value_fn=lambda data: data[DATA_GAS].current_hour.total,
+        attr_fn=lambda data: {'prices': data[DATA_GAS].asdict('total')},
     ),
     FrankEnergieEntityDescription(
         key="gas_market",
         name="Current gas market price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
         value_fn=lambda data: data[DATA_GAS].current_hour.market_price,
+        attr_fn=lambda data: {'prices': data[DATA_GAS].asdict('market_price')},
     ),
     FrankEnergieEntityDescription(
         key="gas_tax",
         name="Current gas price including tax",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
         value_fn=lambda data: data[DATA_GAS].current_hour.market_price_with_tax,
+        attr_fn=lambda data: {'prices': data[DATA_GAS].asdict('market_price_with_tax')},
     ),
     FrankEnergieEntityDescription(
         key="gas_tax_vat",

--- a/custom_components/frank_energie/price_data.py
+++ b/custom_components/frank_energie/price_data.py
@@ -82,3 +82,11 @@ class PriceData:
     def get_future_prices(self):
         """ Prices for hours after the current one. """
         return [hour for hour in self.price_data if hour.for_future]
+
+    def asdict(self, attr):
+        """ Return a dict that can be used as entity attribute data. """
+        return [{
+            'from': e.date_from,
+            'till': e.date_till,
+            'price': getattr(e, attr)
+        } for e in self.price_data]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timedelta
+from http import HTTPStatus
+
+from homeassistant.const import CONTENT_TYPE_JSON
+from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMockResponse
+
+from custom_components.frank_energie import const
+
+
+class ResponseMocks:
+    """ Simple iterator to iterate through a set of responses. """
+
+    def __init__(self):
+        self._responses = []
+        self._index = 0
+        self._cyclic = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._index < len(self._responses):
+            response = self._responses[self._index]
+            self._index += 1
+            if self._cyclic:
+                self._index %= len(self._responses)
+            return response
+
+        raise StopIteration
+
+    def cyclic(self):
+        """ Makes the iterator cycle endlessly through the set responses. """
+        self._cyclic = True
+
+    def add(self, start_date: datetime, electricity_prices: list, gas_prices: list,
+            http_status: int = HTTPStatus.OK):
+        """ Add a response mock. """
+        self._responses.append(
+            AiohttpClientMockResponse(
+                'POST',
+                const.DATA_URL,
+                json={
+                    'data': {
+                        'marketPricesElectricity': self._generate_prices_response(start_date, electricity_prices),
+                        'marketPricesGas': self._generate_prices_response(start_date, gas_prices)
+                    }
+                },
+                headers={"Content-Type": CONTENT_TYPE_JSON},
+                status=http_status
+            )
+        )
+
+    def _generate_prices_response(self, start: datetime, all_in_prices: list | range):
+        """ Generate a list of prices. """
+        start = start.replace(second=0, microsecond=0)
+        return [
+            {
+                'from': (start + timedelta(hours=i)).astimezone().isoformat(),
+                'till': (start + timedelta(hours=i + 1)).astimezone().isoformat(),
+                'marketPrice': 0.7 * price,
+                'marketPriceTax': 0.05 * price,
+                'sourcingMarkupPrice': 0.1 * price,
+                'energyTaxPrice': 0.15 * price,
+            } for i, price in enumerate(all_in_prices)
+        ]


### PR DESCRIPTION
Deze PR voegt een uur-prijs attribuut toe met alle bekende prijzen voor de sensors die standaard aan staan. Dit geeft de mogelijkheid om eigen sensors te maken adhv sjablonen.

Fixes #46.