### PR TITLE
Remove Monetary device class

### DIFF
--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -42,7 +42,6 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
 
     _attr_attribution = ATTRIBUTION
     _attr_icon = ICON
-    _attr_device_class = SensorDeviceClass.MONETARY
     _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator: FrankEnergieCoordinator, description: FrankEnergieEntityDescription) -> None:


### PR DESCRIPTION
Closes #54 

Device class `Monetary` wordt op dit moment niet veel gebruikt binnen HA en geeft nu alleen een icoontje aan de sensor. Omdat dit al gebeurd is er geen verlies in functies. (Voor zover ik weet en getest)