### PR TITLE
Streamline config flow with core

### DIFF
--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant import config_entries
-from .const import COMPONENT_TITLE, DOMAIN, UNIQUE_ID
+from .const import COMPONENT_TITLE, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -16,13 +16,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle adding the config, no user input is needed."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=None
-            )
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
 
-        # Abort if we're adding a new config and the unique id is already in use, else create the entry
-        # For now it's only possible to add the Frank Energie integration once
-        await self.async_set_unique_id(UNIQUE_ID)
-        self._abort_if_unique_id_configured()
-        return self.async_create_entry(title=COMPONENT_TITLE, data={})
+        if user_input is not None:
+            return self.async_create_entry(title=COMPONENT_TITLE, data={})
+
+        return self.async_show_form(step_id="user")

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -2,8 +2,11 @@
   "config": {
     "step": {
       "user": {
-          "description": "No authentication or configuration needed."
+        "description": "[%key:common::config_flow::description::confirm_setup%]"
       }
+    },
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   }
 }

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -2,8 +2,11 @@
     "config": {
         "step": {
             "user": {
-                "description": "No authentication or configuration needed."
+                "description": "Do you want to start setup?"
             }
+        },
+        "abort": {
+            "single_instance_allowed": "Already configured. Only a single configuration possible."
         }
     }
 }

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -2,8 +2,11 @@
     "config": {
         "step": {
             "user": {
-                "description": "Geen authenticatie of configuratie nodig."
+                "description": "Wil je beginnen met instellen?"
             }
+        },
+        "abort": {
+            "single_instance_allowed": "Al geconfigureerd. Slechts \u00e9\u00e9n configuratie mogelijk."
         }
     }
 }


### PR DESCRIPTION
Een paar extra meldingen (met standaard inhoud) en een no-input installatie gelijkgetrokken met core integraties (zie https://github.com/home-assistant/core/blob/ab2ab1573eb4684b5bafdeff83d5461863314070/homeassistant/components/sun/config_flow.py#L17-L27)