### PR TITLE
Reorder init steps to handle failed first_refresh

### DIFF
--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -22,13 +22,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     web_session_client = async_get_clientsession(hass)
     frank_coordinator = FrankEnergieCoordinator(hass, web_session_client)
 
+    # Fetch initial data, so we have data when entities subscribe and set up the platform
+    await frank_coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         CONF_COORDINATOR: frank_coordinator,
     }
 
-    # Fetch initial data, so we have data when entities subscribe and set up the platform
-    await frank_coordinator.async_config_entry_first_refresh()
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True


### PR DESCRIPTION
Wissel toevoegen `hass.data` en `async_config_entry_first_refresh()`.

Als `first_refresh` mislukt is er wel al informatie opgeslagen in `hass.data`, dit geeft problemen als de gebruiker de integratie herlaadt. Door dit om te draaien voorkom je deze situatie.