### PR TITLE
Implement sign-in flow to get extra account information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# All pycache folders in all folders
+__pycache__/
+
+# HA files to allow for local development
+.HA_VERSION
+.storage/
+*.yaml
+blueprints/
+*.log*
+*.db

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Vervolgens kunnen sensoren per stuk worden uitgeschakeld of verborgen indien gew
 
 Indien je deze plugin al gebruikte en hebt ingesteld via `configuration.yaml` dien je deze instellingen te verwijderen en Frank Energie opnieuw in te stellen middels de config flow zoals hierboven beschreven.
 
+#### Inloggen
+
+Tijdens het instellen van de integratie wordt je gevraagd of je wilt inloggen. Op dit moment worden de mogelijkheden hiervan ontwikkeld.
+
 ### Gebruik
 
 Een aantal sensors hebben een `prices` attribuut die alle bekende prijzen bevat. Dit kan worden gebruikt om zelf met een template nieuwe sensors te maken.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Indien je deze plugin al gebruikte en hebt ingesteld via `configuration.yaml` di
 
 #### Inloggen
 
-Tijdens het instellen van de integratie wordt je gevraagd of je wilt inloggen. Op dit moment worden de mogelijkheden hiervan ontwikkeld.
+Tijdens het instellen van de integratie wordt je gevraagd of je wilt inloggen. Als je niet inlogd krijg je de huidige energietarieven van Frank Energie als sensoren, als je wel inlogd komen hier ook sensoren voor verwachte en werkele kosten voor deze maand tot nu toe.
 
 ### Gebruik
 

--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -21,7 +21,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Initialise the coordinator and save it as domain-data
 
-    api = FrankEnergie(clientsession=async_get_clientsession(hass), auth_token=entry.data[CONF_ACCESS_TOKEN])
+    api = FrankEnergie(clientsession=async_get_clientsession(hass), auth_token=entry.data.get(CONF_ACCESS_TOKEN, None))
     frank_coordinator = FrankEnergieCoordinator(hass, api)
 
     # Fetch initial data, so we have data when entities subscribe and set up the platform

--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import Platform, CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_COORDINATOR, DOMAIN
 from .coordinator import FrankEnergieCoordinator
 
-_LOGGER = logging.getLogger(__name__)
+from python_frank_energie import FrankEnergie
+
 PLATFORMS = [Platform.SENSOR]
 
 
@@ -19,8 +20,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the Frank Energie component from a config entry."""
 
     # Initialise the coordinator and save it as domain-data
-    web_session_client = async_get_clientsession(hass)
-    frank_coordinator = FrankEnergieCoordinator(hass, web_session_client)
+
+    api = FrankEnergie(clientsession=async_get_clientsession(hass), auth_token=entry.data[CONF_ACCESS_TOKEN])
+    frank_coordinator = FrankEnergieCoordinator(hass, api)
 
     # Fetch initial data, so we have data when entities subscribe and set up the platform
     await frank_coordinator.async_config_entry_first_refresh()

--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -1,8 +1,6 @@
 """The Frank Energie component."""
 from __future__ import annotations
 
-import logging
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant

--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform, CONF_ACCESS_TOKEN
+from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from python_frank_energie import FrankEnergie
 
 from .const import CONF_COORDINATOR, DOMAIN
 from .coordinator import FrankEnergieCoordinator
-
-from python_frank_energie import FrankEnergie
 
 PLATFORMS = [Platform.SENSOR]
 
@@ -21,12 +20,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # For backwards compat, set unique ID
     if entry.unique_id is None:
-        hass.config_entries.async_update_entry(
-            entry, unique_id=str("frank_energie")
-        )
+        hass.config_entries.async_update_entry(entry, unique_id=str("frank_energie"))
 
     # Initialise the coordinator and save it as domain-data
-    api = FrankEnergie(clientsession=async_get_clientsession(hass), auth_token=entry.data.get(CONF_ACCESS_TOKEN, None))
+    api = FrankEnergie(
+        clientsession=async_get_clientsession(hass),
+        auth_token=entry.data.get(CONF_ACCESS_TOKEN, None),
+    )
     frank_coordinator = FrankEnergieCoordinator(hass, api)
 
     # Fetch initial data, so we have data when entities subscribe and set up the platform

--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -25,7 +25,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         clientsession=async_get_clientsession(hass),
         auth_token=entry.data.get(CONF_ACCESS_TOKEN, None),
     )
-    frank_coordinator = FrankEnergieCoordinator(hass, api)
+    frank_coordinator = FrankEnergieCoordinator(hass, entry, api)
 
     # Fetch initial data, so we have data when entities subscribe and set up the platform
     await frank_coordinator.async_config_entry_first_refresh()

--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -19,8 +19,13 @@ PLATFORMS = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the Frank Energie component from a config entry."""
 
-    # Initialise the coordinator and save it as domain-data
+    # For backwards compat, set unique ID
+    if entry.unique_id is None:
+        hass.config_entries.async_update_entry(
+            entry, unique_id=str("frank_energie")
+        )
 
+    # Initialise the coordinator and save it as domain-data
     api = FrankEnergie(clientsession=async_get_clientsession(hass), auth_token=entry.data.get(CONF_ACCESS_TOKEN, None))
     frank_coordinator = FrankEnergieCoordinator(hass, api)
 

--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -16,8 +16,8 @@ PLATFORMS = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the Frank Energie component from a config entry."""
 
-    # For backwards compat, set unique ID
-    if entry.unique_id is None:
+    # For backwards compatibility, set unique ID
+    if entry.unique_id is None or entry.unique_id == "frank_energie_component":
         hass.config_entries.async_update_entry(entry, unique_id=str("frank_energie"))
 
     # Initialise the coordinator and save it as domain-data

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -1,8 +1,6 @@
 """Config flow for Picnic integration."""
 from __future__ import annotations
 
-import logging
-
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import (CONF_ACCESS_TOKEN, CONF_AUTHENTICATION,
@@ -10,9 +8,7 @@ from homeassistant.const import (CONF_ACCESS_TOKEN, CONF_AUTHENTICATION,
 from python_frank_energie import FrankEnergie
 from python_frank_energie.exceptions import AuthException
 
-from .const import COMPONENT_TITLE, DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
+from .const import DOMAIN
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -54,9 +50,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         api = FrankEnergie()
         try:
-            auth = await api.login(
-                user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
-            )
+            auth = await api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
         except AuthException:
             return self.async_step_login({"base": "invalid_auth"})
         finally:

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -51,12 +51,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors=errors,
             )
 
-        api = FrankEnergie()
-
-        try:
-            auth = await api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
-        except AuthException:
-            return self.async_step_login({"base": "invalid_auth"})
+        with FrankEnergie as api:
+            try:
+                auth = await api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
+            except AuthException:
+                return self.async_step_login({"base": "invalid_auth"})
 
         await self.async_set_unique_id(user_input[CONF_USERNAME])
         self._abort_if_unique_id_configured()

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -52,13 +52,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors=errors,
             )
 
-        with FrankEnergie as api:
-            try:
-                auth = await api.login(
-                    user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
-                )
-            except AuthException:
-                return self.async_step_login({"base": "invalid_auth"})
+        api = FrankEnergie()
+        try:
+            auth = await api.login(
+                user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+            )
+        except AuthException:
+            return self.async_step_login({"base": "invalid_auth"})
+        finally:
+            await api.close()
 
         await self.async_set_unique_id(user_input[CONF_USERNAME])
         self._abort_if_unique_id_configured()

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -18,6 +18,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle the config flow for Frank Energie."""
 
@@ -41,7 +42,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         async with FrankEnergie() as api:
             try:
-                auth = await api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
+                auth = await api.login(
+                    user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+                )
             except AuthException as ex:
                 _LOGGER.exception("Error during login", exc_info=ex)
                 return await self.async_step_login(errors={"base": "invalid_auth"})

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -62,7 +62,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         data = {
-            CONF_USERNAME: "Frank Energie",
+            CONF_USERNAME: user_input[CONF_USERNAME],
             CONF_ACCESS_TOKEN: auth.authToken,
             CONF_TOKEN: auth.refreshToken
         }
@@ -87,15 +87,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input[CONF_AUTHENTICATION]:
             return await self.async_step_login()
 
-        data = {
-            CONF_USERNAME: "Frank Energie",
-        }
+        data = {}
 
         return await self._async_create_entry(data)
 
     async def _async_create_entry(self, data):
 
-        await self.async_set_unique_id(data[CONF_USERNAME])
+        await self.async_set_unique_id(data.get(CONF_USERNAME, "frank_energie"))
         self._abort_if_unique_id_configured()
 
-        return self.async_create_entry(title=data[CONF_USERNAME], data=data)
+        return self.async_create_entry(title=data.get(CONF_USERNAME, "Frank Energie"), data=data)

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import (CONF_ACCESS_TOKEN, CONF_AUTHENTICATION,
-                                 CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME)
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_AUTHENTICATION,
+    CONF_PASSWORD,
+    CONF_TOKEN,
+    CONF_USERNAME,
+)
 from python_frank_energie import FrankEnergie
 from python_frank_energie.exceptions import AuthException
 
@@ -15,22 +20,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle the config flow for Frank Energie."""
 
     VERSION = 1
-
-    def _show_setup_form(self, errors=None):
-        """Show the setup form to the user."""
-
-        data_schema = vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): str,
-                vol.Required(CONF_PASSWORD): str,
-            }
-        )
-
-        return self.async_show_form(
-            step_id="user",
-            data_schema=data_schema,
-            errors=errors,
-        )
 
     async def async_step_login(self, user_input=None, errors=None):
         """Handle login with credentials by user."""

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -2,15 +2,14 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
+from typing import Any
+
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import (
-    CONF_ACCESS_TOKEN,
-    CONF_AUTHENTICATION,
-    CONF_PASSWORD,
-    CONF_TOKEN,
-    CONF_USERNAME,
-)
+from homeassistant.const import (CONF_ACCESS_TOKEN, CONF_AUTHENTICATION,
+                                 CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME)
+from homeassistant.data_entry_flow import FlowResult
 from python_frank_energie import FrankEnergie
 from python_frank_energie.exceptions import AuthException
 
@@ -24,12 +23,20 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_login(self, user_input=None, errors=None):
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._reauth_entry = None
+
+    async def async_step_login(self, user_input=None, errors=None) -> FlowResult:
         """Handle login with credentials by user."""
         if not user_input:
+            username = (
+                self._reauth_entry.data[CONF_USERNAME] if self._reauth_entry else None
+            )
+
             data_schema = vol.Schema(
                 {
-                    vol.Required(CONF_USERNAME): str,
+                    vol.Required(CONF_USERNAME, default=username): str,
                     vol.Required(CONF_PASSWORD): str,
                 }
             )
@@ -49,18 +56,25 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Error during login", exc_info=ex)
                 return await self.async_step_login(errors={"base": "invalid_auth"})
 
-        await self.async_set_unique_id(user_input[CONF_USERNAME])
-        self._abort_if_unique_id_configured()
-
         data = {
             CONF_USERNAME: user_input[CONF_USERNAME],
             CONF_ACCESS_TOKEN: auth.authToken,
             CONF_TOKEN: auth.refreshToken,
         }
 
+        if self._reauth_entry:
+            self.hass.config_entries.async_update_entry(
+                self._reauth_entry,
+                data=data,
+            )
+            return self.async_abort(reason="reauth_successful")
+
+        await self.async_set_unique_id(user_input[CONF_USERNAME])
+        self._abort_if_unique_id_configured()
+
         return await self._async_create_entry(data)
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle a flow initiated by the user."""
         if not user_input:
             data_schema = vol.Schema(
@@ -77,6 +91,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         data = {}
 
         return await self._async_create_entry(data)
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+        """Handle configuration by re-auth."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_login()
 
     async def _async_create_entry(self, data):
         await self.async_set_unique_id(data.get(CONF_USERNAME, "frank_energie"))

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Picnic integration."""
 from __future__ import annotations
 
+import logging
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import (
@@ -15,6 +16,7 @@ from python_frank_energie.exceptions import AuthException
 
 from .const import DOMAIN
 
+_LOGGER = logging.getLogger(__name__)
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle the config flow for Frank Energie."""
@@ -40,8 +42,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         async with FrankEnergie() as api:
             try:
                 auth = await api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
-            except AuthException:
-                return self.async_step_login({"base": "invalid_auth"})
+            except AuthException as ex:
+                _LOGGER.exception("Error during login", exc_info=ex)
+                return await self.async_step_login(errors={"base": "invalid_auth"})
 
         await self.async_set_unique_id(user_input[CONF_USERNAME])
         self._abort_if_unique_id_configured()

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -7,8 +7,13 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import (CONF_ACCESS_TOKEN, CONF_AUTHENTICATION,
-                                 CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME)
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_AUTHENTICATION,
+    CONF_PASSWORD,
+    CONF_TOKEN,
+    CONF_USERNAME,
+)
 from homeassistant.data_entry_flow import FlowResult
 from python_frank_energie import FrankEnergie
 from python_frank_energie.exceptions import AuthException

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -37,13 +37,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors=errors,
             )
 
-        api = FrankEnergie()
-        try:
-            auth = await api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
-        except AuthException:
-            return self.async_step_login({"base": "invalid_auth"})
-        finally:
-            await api.close()
+        async with FrankEnergie() as api:
+            try:
+                auth = await api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
+            except AuthException:
+                return self.async_step_login({"base": "invalid_auth"})
 
         await self.async_set_unique_id(user_input[CONF_USERNAME])
         self._abort_if_unique_id_configured()

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant import config_entries
-from .const import COMPONENT_TITLE, DOMAIN
 import voluptuous as vol
-from homeassistant.const import CONF_ACCESS_TOKEN, CONF_PASSWORD, CONF_USERNAME, CONF_AUTHENTICATION, CONF_TOKEN
-
+from homeassistant import config_entries
+from homeassistant.const import (CONF_ACCESS_TOKEN, CONF_AUTHENTICATION,
+                                 CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME)
 from python_frank_energie import FrankEnergie
 from python_frank_energie.exceptions import AuthException
+
+from .const import COMPONENT_TITLE, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,8 +25,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         data_schema = vol.Schema(
             {
-            vol.Required(CONF_USERNAME): str,
-            vol.Required(CONF_PASSWORD): str,
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
             }
         )
 
@@ -40,8 +41,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not user_input:
             data_schema = vol.Schema(
                 {
-                vol.Required(CONF_USERNAME): str,
-                vol.Required(CONF_PASSWORD): str,
+                    vol.Required(CONF_USERNAME): str,
+                    vol.Required(CONF_PASSWORD): str,
                 }
             )
 
@@ -53,7 +54,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         with FrankEnergie as api:
             try:
-                auth = await api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
+                auth = await api.login(
+                    user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+                )
             except AuthException:
                 return self.async_step_login({"base": "invalid_auth"})
 
@@ -63,25 +66,21 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         data = {
             CONF_USERNAME: user_input[CONF_USERNAME],
             CONF_ACCESS_TOKEN: auth.authToken,
-            CONF_TOKEN: auth.refreshToken
+            CONF_TOKEN: auth.refreshToken,
         }
 
         return await self._async_create_entry(data)
-
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initiated by the user."""
         if not user_input:
             data_schema = vol.Schema(
                 {
-                vol.Required(CONF_AUTHENTICATION): bool,
+                    vol.Required(CONF_AUTHENTICATION): bool,
                 }
             )
 
-            return self.async_show_form(
-                step_id="user",
-                data_schema=data_schema
-            )
+            return self.async_show_form(step_id="user", data_schema=data_schema)
 
         if user_input[CONF_AUTHENTICATION]:
             return await self.async_step_login()
@@ -91,8 +90,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self._async_create_entry(data)
 
     async def _async_create_entry(self, data):
-
         await self.async_set_unique_id(data.get(CONF_USERNAME, "frank_energie"))
         self._abort_if_unique_id_configured()
 
-        return self.async_create_entry(title=data.get(CONF_USERNAME, "Frank Energie"), data=data)
+        return self.async_create_entry(
+            title=data.get(CONF_USERNAME, "Frank Energie"), data=data
+        )

--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -10,5 +10,5 @@ COMPONENT_TITLE = "Frank Energie"
 CONF_COORDINATOR = "coordinator"
 ATTR_TIME = "from_time"
 
-DATA_ELECTRICITY = 'electricity'
-DATA_GAS = 'gas'
+DATA_ELECTRICITY = "electricity"
+DATA_GAS = "gas"

--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -5,7 +5,6 @@ ATTRIBUTION = "Data provided by Frank Energie"
 DOMAIN = "frank_energie"
 DATA_URL = "https://frank-graphql-prod.graphcdn.app/"
 ICON = "mdi:currency-eur"
-UNIQUE_ID = f"{DOMAIN}_component"
 COMPONENT_TITLE = "Frank Energie"
 
 CONF_COORDINATOR = "coordinator"

--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -1,3 +1,4 @@
+"""Constants for the Frank Energie integration."""
 from __future__ import annotations
 
 ATTRIBUTION = "Data provided by Frank Energie"
@@ -12,3 +13,4 @@ ATTR_TIME = "from_time"
 
 DATA_ELECTRICITY = "electricity"
 DATA_GAS = "gas"
+DATA_MONTH_SUMMARY = "month_summary"

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from .const import DATA_ELECTRICITY, DATA_GAS
 
@@ -17,10 +19,10 @@ class FrankEnergieCoordinator(DataUpdateCoordinator):
 
     api: FrankEnergie
 
-    def __init__(self, hass: HomeAssistant, websession) -> None:
+    def __init__(self, hass: HomeAssistant, api: FrankEnergie) -> None:
         """Initialize the data object."""
         self.hass = hass
-        self.api = FrankEnergie(clientsession=websession)
+        self.api = api
 
         logger = logging.getLogger(__name__)
         super().__init__(

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1,16 +1,15 @@
+"""Coordinator implementation for Frank Energie integration."""
 from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (DataUpdateCoordinator,
                                                       UpdateFailed)
 from python_frank_energie import FrankEnergie
 
-from .const import DATA_ELECTRICITY, DATA_GAS
+from .const import DATA_ELECTRICITY, DATA_GAS, DATA_MONTH_SUMMARY
 
 LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +33,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator):
         )
 
     async def _async_update_data(self) -> dict:
-        """Get the latest data from Frank Energie"""
+        """Get the latest data from Frank Energie."""
         self.logger.debug("Fetching Frank Energie data")
 
         # We request data for today up until the day after tomorrow.
@@ -63,7 +62,12 @@ class FrankEnergieCoordinator(DataUpdateCoordinator):
             # Re-raise the error if there's no data from future left
             raise err
 
+        data_month_summary = (
+            await self.api.monthSummary() if self.api.is_authenticated else None
+        )
+
         return {
             DATA_ELECTRICITY: data_today_electricity + data_tomorrow_electricity,
             DATA_GAS: data_today_gas + data_tomorrow_gas,
+            DATA_MONTH_SUMMARY: data_month_summary,
         }

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -5,8 +5,7 @@ import logging
 from datetime import datetime, timedelta
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import (DataUpdateCoordinator,
-                                                      UpdateFailed)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from python_frank_energie import FrankEnergie
 
 from .const import DATA_ELECTRICITY, DATA_GAS, DATA_MONTH_SUMMARY

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -7,8 +7,7 @@ from datetime import datetime, timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers.update_coordinator import (DataUpdateCoordinator,
-                                                      UpdateFailed)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from python_frank_energie import FrankEnergie
 from python_frank_energie.exceptions import RequestException
 

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -4,12 +4,13 @@ import logging
 from datetime import datetime, timedelta
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
 from homeassistant.const import CONF_ACCESS_TOKEN
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from .const import DATA_ELECTRICITY, DATA_GAS
-
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import (DataUpdateCoordinator,
+                                                      UpdateFailed)
 from python_frank_energie import FrankEnergie
+
+from .const import DATA_ELECTRICITY, DATA_GAS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,8 +46,12 @@ class FrankEnergieCoordinator(DataUpdateCoordinator):
         # Fetch data for today and tomorrow separately,
         # because the gas prices response only contains data for the first day of the query
         try:
-            (data_today_electricity, data_today_gas) = await self.api.prices(today, tomorrow)
-            (data_tomorrow_electricity, data_tomorrow_gas) = await self.api.prices(tomorrow, day_after_tomorrow)
+            (data_today_electricity, data_today_gas) = await self.api.prices(
+                today, tomorrow
+            )
+            (data_tomorrow_electricity, data_tomorrow_gas) = await self.api.prices(
+                tomorrow, day_after_tomorrow
+            )
         except UpdateFailed as err:
             # Check if we still have data to work with, if so, return this data. Still log the error as warning
             if (

--- a/custom_components/frank_energie/manifest.json
+++ b/custom_components/frank_energie/manifest.json
@@ -7,7 +7,7 @@
   "issue_tracker": "https://github.com/bajansen/home-assistant-frank_energie/issues",
   "iot_class": "cloud_polling",
   "requirements": [
-    "python-frank-energie==2.0.0"
+    "python-frank-energie==3.0.0a2"
   ],
   "version": "1.0.0"
 }

--- a/custom_components/frank_energie/manifest.json
+++ b/custom_components/frank_energie/manifest.json
@@ -7,7 +7,7 @@
   "issue_tracker": "https://github.com/bajansen/home-assistant-frank_energie/issues",
   "iot_class": "cloud_polling",
   "requirements": [
-    "python-frank-energie==3.0.0"
+    "python-frank-energie==3.1.0"
   ],
   "version": "1.0.0"
 }

--- a/custom_components/frank_energie/manifest.json
+++ b/custom_components/frank_energie/manifest.json
@@ -7,7 +7,7 @@
   "issue_tracker": "https://github.com/bajansen/home-assistant-frank_energie/issues",
   "iot_class": "cloud_polling",
   "requirements": [
-    "python-frank-energie==3.0.0a2"
+    "python-frank-energie==3.0.0"
   ],
   "version": "1.0.0"
 }

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Callable
 
-from homeassistant.components.sensor import (SensorEntity,
+from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
                                              SensorEntityDescription,
                                              SensorStateClass)
 from homeassistant.config_entries import ConfigEntry
@@ -23,7 +23,7 @@ from homeassistant.util import utcnow
 from python_frank_energie.models import PriceData
 
 from .const import (ATTR_TIME, ATTRIBUTION, CONF_COORDINATOR, DATA_ELECTRICITY,
-                    DATA_GAS, DOMAIN, ICON)
+                    DATA_GAS, DATA_MONTH_SUMMARY, DOMAIN, ICON)
 from .coordinator import FrankEnergieCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,6 +33,7 @@ _LOGGER = logging.getLogger(__name__)
 class FrankEnergieEntityDescription(SensorEntityDescription):
     """Describes Frank Energie sensor entity."""
 
+    authenticated: bool = False
     value_fn: Callable[[dict[PriceData]], StateType] = None
     attr_fn: Callable[[dict[PriceData]], dict[str, StateType | list]] = lambda _: {}
 
@@ -43,6 +44,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current electricity price (All-in)",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.total,
         attr_fn=lambda data: {"prices": data[DATA_ELECTRICITY].asdict("total")},
     ),
@@ -51,6 +53,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current electricity market price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.market_price,
         attr_fn=lambda data: {"prices": data[DATA_ELECTRICITY].asdict("market_price")},
     ),
@@ -59,6 +62,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current electricity price including tax",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.market_price_with_tax,
         attr_fn=lambda data: {
             "prices": data[DATA_ELECTRICITY].asdict("market_price_with_tax")
@@ -69,6 +73,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current electricity VAT price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.market_price_tax,
         entity_registry_enabled_default=False,
     ),
@@ -77,6 +82,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current electricity sourcing markup",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.sourcing_markup_price,
         entity_registry_enabled_default=False,
     ),
@@ -85,6 +91,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current electricity tax only",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_ELECTRICITY].current_hour.energy_tax_price,
         entity_registry_enabled_default=False,
     ),
@@ -93,6 +100,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current gas price (All-in)",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_GAS].current_hour.total,
         attr_fn=lambda data: {"prices": data[DATA_GAS].asdict("total")},
     ),
@@ -101,6 +109,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current gas market price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_GAS].current_hour.market_price,
         attr_fn=lambda data: {"prices": data[DATA_GAS].asdict("market_price")},
     ),
@@ -109,6 +118,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current gas price including tax",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_GAS].current_hour.market_price_with_tax,
         attr_fn=lambda data: {"prices": data[DATA_GAS].asdict("market_price_with_tax")},
     ),
@@ -117,6 +127,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current gas VAT price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_GAS].current_hour.market_price_tax,
         entity_registry_enabled_default=False,
     ),
@@ -125,6 +136,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current gas sourcing price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_GAS].current_hour.sourcing_markup_price,
         entity_registry_enabled_default=False,
     ),
@@ -133,6 +145,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Current gas tax only",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_GAS].current_hour.energy_tax_price,
         entity_registry_enabled_default=False,
     ),
@@ -141,6 +154,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Lowest gas price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_GAS].today_min.total,
         attr_fn=lambda data: {ATTR_TIME: data[DATA_GAS].today_min.date_from},
     ),
@@ -149,6 +163,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Highest gas price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_GAS].today_max.total,
         attr_fn=lambda data: {ATTR_TIME: data[DATA_GAS].today_max.date_from},
     ),
@@ -157,6 +172,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Lowest energy price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_ELECTRICITY].today_min.total,
         attr_fn=lambda data: {ATTR_TIME: data[DATA_ELECTRICITY].today_min.date_from},
     ),
@@ -165,6 +181,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Highest energy price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_ELECTRICITY].today_max.total,
         attr_fn=lambda data: {ATTR_TIME: data[DATA_ELECTRICITY].today_max.date_from},
     ),
@@ -173,7 +190,36 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         name="Average electricity price today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data[DATA_ELECTRICITY].today_avg,
+    ),
+    FrankEnergieEntityDescription(
+        key="actual_costs_until_last_meter_reading_date",
+        name="Actual cost",
+        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.TOTAL,
+        native_unit_of_measurement=CURRENCY_EURO,
+        authenticated=True,
+        value_fn=lambda data: data[
+            DATA_MONTH_SUMMARY
+        ].actualCostsUntilLastMeterReadingDate,
+        attr_fn=lambda data: {
+            "Last update": data[DATA_MONTH_SUMMARY].lastMeterReadingDate
+        },
+    ),
+    FrankEnergieEntityDescription(
+        key="expected_costs_until_last_meter_reading_date",
+        name="Expected Cost",
+        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.TOTAL,
+        native_unit_of_measurement=CURRENCY_EURO,
+        authenticated=True,
+        value_fn=lambda data: data[
+            DATA_MONTH_SUMMARY
+        ].expectedCostsUntilLastMeterReadingDate,
+        attr_fn=lambda data: {
+            "Last update": data[DATA_MONTH_SUMMARY].lastMeterReadingDate
+        },
     ),
 )
 
@@ -186,11 +232,13 @@ async def async_setup_entry(
     """Set up Frank Energie sensor entries."""
     frank_coordinator = hass.data[DOMAIN][config_entry.entry_id][CONF_COORDINATOR]
 
-    # Add an entity for each sensor type
+    # Add an entity for each sensor type, when authenticated is True,
+    # only add the entity if the user is authenticated
     async_add_entities(
         [
             FrankEnergieSensor(frank_coordinator, description, config_entry)
             for description in SENSOR_TYPES
+            if not description.authenticated or frank_coordinator.api.is_authenticated
         ],
         True,
     )
@@ -201,7 +249,6 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
 
     _attr_attribution = ATTRIBUTION
     _attr_icon = ICON
-    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
         self,

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -223,7 +223,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
     ),
     FrankEnergieEntityDescription(
         key="expected_costs_until_last_meter_reading_date",
-        name="Expected Cost",
+        name="Expected monthly cost",
         device_class=SensorDeviceClass.MONETARY,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=CURRENCY_EURO,

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -6,17 +6,12 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Callable
 
-from homeassistant.components.sensor import (
-    SensorEntity,
-    SensorEntityDescription,
-    SensorStateClass,
-)
+from homeassistant.components.sensor import (SensorEntity,
+                                             SensorEntityDescription,
+                                             SensorStateClass)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CURRENCY_EURO,
-    ENERGY_KILO_WATT_HOUR,
-    VOLUME_CUBIC_METERS,
-)
+from homeassistant.const import (CURRENCY_EURO, ENERGY_KILO_WATT_HOUR,
+                                 VOLUME_CUBIC_METERS)
 from homeassistant.core import HassJob, HomeAssistant
 from homeassistant.helpers import event
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -25,18 +20,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import utcnow
-
-from .const import (
-    ATTR_TIME,
-    ATTRIBUTION,
-    CONF_COORDINATOR,
-    DATA_ELECTRICITY,
-    DATA_GAS,
-    DOMAIN,
-    ICON,
-)
-from .coordinator import FrankEnergieCoordinator
 from python_frank_energie.models import PriceData
+
+from .const import (ATTR_TIME, ATTRIBUTION, CONF_COORDINATOR, DATA_ELECTRICITY,
+                    DATA_GAS, DOMAIN, ICON)
+from .coordinator import FrankEnergieCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -219,7 +207,7 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
         self,
         coordinator: FrankEnergieCoordinator,
         description: FrankEnergieEntityDescription,
-        entry: ConfigEntry
+        entry: ConfigEntry,
     ) -> None:
         """Initialize the sensor."""
         self.entity_description: FrankEnergieEntityDescription = description

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -6,12 +6,18 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Callable
 
-from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
-                                             SensorEntityDescription,
-                                             SensorStateClass)
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (CURRENCY_EURO, ENERGY_KILO_WATT_HOUR,
-                                 VOLUME_CUBIC_METERS)
+from homeassistant.const import (
+    CURRENCY_EURO,
+    ENERGY_KILO_WATT_HOUR,
+    VOLUME_CUBIC_METERS,
+)
 from homeassistant.core import HassJob, HomeAssistant
 from homeassistant.helpers import event
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -22,8 +28,16 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import utcnow
 from python_frank_energie.models import PriceData
 
-from .const import (ATTR_TIME, ATTRIBUTION, CONF_COORDINATOR, DATA_ELECTRICITY,
-                    DATA_GAS, DATA_MONTH_SUMMARY, DOMAIN, ICON)
+from .const import (
+    ATTR_TIME,
+    ATTRIBUTION,
+    CONF_COORDINATOR,
+    DATA_ELECTRICITY,
+    DATA_GAS,
+    DATA_MONTH_SUMMARY,
+    DOMAIN,
+    ICON,
+)
 from .coordinator import FrankEnergieCoordinator
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -209,7 +209,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
     ),
     FrankEnergieEntityDescription(
         key="actual_costs_until_last_meter_reading_date",
-        name="Actual cost",
+        name="Actual monthly cost",
         device_class=SensorDeviceClass.MONETARY,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=CURRENCY_EURO,

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -223,7 +223,7 @@ class FrankEnergieSensor(CoordinatorEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         self.entity_description: FrankEnergieEntityDescription = description
-        self._attr_unique_id = f"frank_energie.{description.key}"
+        self._attr_unique_id = f"{entry.unique_id}.{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{entry.entry_id}")},
             name="Frank Energie",

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -6,18 +6,12 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Callable
 
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorEntity,
-    SensorEntityDescription,
-    SensorStateClass,
-)
+from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
+                                             SensorEntityDescription,
+                                             SensorStateClass)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CURRENCY_EURO,
-    ENERGY_KILO_WATT_HOUR,
-    VOLUME_CUBIC_METERS,
-)
+from homeassistant.const import (CURRENCY_EURO, ENERGY_KILO_WATT_HOUR,
+                                 VOLUME_CUBIC_METERS)
 from homeassistant.core import HassJob, HomeAssistant
 from homeassistant.helpers import event
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -28,16 +22,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import utcnow
 from python_frank_energie.models import PriceData
 
-from .const import (
-    ATTR_TIME,
-    ATTRIBUTION,
-    CONF_COORDINATOR,
-    DATA_ELECTRICITY,
-    DATA_GAS,
-    DATA_MONTH_SUMMARY,
-    DOMAIN,
-    ICON,
-)
+from .const import (ATTR_TIME, ATTRIBUTION, CONF_COORDINATOR, DATA_ELECTRICITY,
+                    DATA_GAS, DATA_MONTH_SUMMARY, DOMAIN, ICON)
 from .coordinator import FrankEnergieCoordinator
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Account is already configured"
+            "already_configured": "Account is already configured",
+            "reauth_successful": "Re-authentication was successful"
         },
         "error": {
             "invalid_auth": "Credentials rejected, please check your username and password."

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -4,7 +4,7 @@
             "already_configured": "Account is already configured"
         },
         "error": {
-            "invalid_auth": "Invalid authentication"
+            "invalid_auth": "Credentials rejected, please check your username and password."
         },
         "step": {
             "login": {

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -1,12 +1,27 @@
 {
     "config": {
-        "step": {
-            "user": {
-                "description": "Do you want to start setup?"
-            }
-        },
         "abort": {
-            "single_instance_allowed": "Already configured. Only a single configuration possible."
+            "already_configured": "Account is already configured"
+        },
+        "error": {
+            "invalid_auth": "Invalid authentication"
+        },
+        "step": {
+            "login": {
+                "data": {
+                    "password": "Password",
+                    "username": "Username / e-mail"
+                },
+                "title": "Enter your Frank Energie information"
+            },
+            "user": {
+                "data": {
+                    "authentication": "Sign in"
+                },
+                "title": "Do you want to sign in?",
+                "description": "Frank Energie can be used without account, if you only want energy price data you can skip signing in."
+            }
         }
-    }
+    },
+    "title": "Frank Energie"
 }

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -4,7 +4,7 @@
             "already_configured": "Account is al toegevoegd"
         },
         "error": {
-            "invalid_auth": "Invalid authentication"
+            "invalid_auth": "Inloggegevens niet geaccepteerd, controller de gegevens en probeer het opnieuw."
         },
         "step": {
             "login": {

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -1,12 +1,27 @@
 {
     "config": {
-        "step": {
-            "user": {
-                "description": "Wil je beginnen met instellen?"
-            }
-        },
         "abort": {
-            "single_instance_allowed": "Al geconfigureerd. Slechts \u00e9\u00e9n configuratie mogelijk."
+            "already_configured": "Account is al toegevoegd"
+        },
+        "error": {
+            "invalid_auth": "Invalid authentication"
+        },
+        "step": {
+            "login": {
+                "data": {
+                    "password": "Wachtwoord",
+                    "username": "Gebruikersnaam / e-mail"
+                },
+                "title": "Vul de login gegevens in"
+            },
+            "user": {
+                "data": {
+                    "authentication": "Log in"
+                },
+                "title": "Wil je inloggen voor Frank Energie?",
+                "description": "Frank Energie kan gebruikt worden zonder account, als je alleen energie prijs data wilt kun je inloggen overslaan."
+            }
         }
-    }
+    },
+    "title": "Frank Energie"
 }

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Account is al toegevoegd"
+            "already_configured": "Account is al toegevoegd",
+            "reauth_successful": "Opnieuw inloggen gelukt"
         },
         "error": {
             "invalid_auth": "Inloggegevens niet geaccepteerd, controller de gegevens en probeer het opnieuw."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest-homeassistant-custom-component~=0.13.7
 flake8~=5.0.4
 pytest~=7.2.1
-python-frank-energie~=2.0.0
+python-frank-energie~=3.1.0


### PR DESCRIPTION
This adds a 'do you want to sign in' question during first setup. For now you won't get any extra information but it is easy to implement when this is added!

Things to do (in a follow up or here)
- [x] Implement reauth flow (when users resets its password or 'auth_token' is invalidated). Waits for https://github.com/DCSBL/python-frank-energie/issues/19
- [x] Make it possible for user to sign in without removing integration. → Users can configure a new 'Frank Energie' component, side by side
- [x] Test multiple configurations (maybe someone has more than one 'Frank energie' account 🤷)
- [ ] Tests!
- [x] Implement cool new datapoints (like how many trees you planted 🌴)
- [x] Make sure feature is backwards compatible with existing configurations
- [x] Fix 'unique_id' not set