### PR TITLE
Set release version automaticly and zip files for HACS

### DIFF
--- a/.github/helpers/update_manifest.py
+++ b/.github/helpers/update_manifest.py
@@ -15,6 +15,10 @@ def update_manifest():
         if value in ["--version", "-V"]:
             version = sys.argv[index + 1]
 
+    # Remove the v from the version number if it exists
+    if version[0] == "v":
+        version = version[1:]
+
     with open(
         f"{os.getcwd()}/custom_components/frank_energie/manifest.json"
     ) as manifestfile:

--- a/.github/helpers/update_manifest.py
+++ b/.github/helpers/update_manifest.py
@@ -1,0 +1,27 @@
+"""Update the manifest file."""
+"""Idea from https://github.com/hacs/integration/blob/main/manage/update_manifest.py"""
+
+import sys
+import json
+import os
+
+
+def update_manifest():
+    """Update the manifest file."""
+    version = "0.0.0"
+    for index, value in enumerate(sys.argv):
+        if value in ["--version", "-V"]:
+            version = sys.argv[index + 1]
+
+    with open(f"{os.getcwd()}/custom_components/frank_energie/manifest.json") as manifestfile:
+        manifest = json.load(manifestfile)
+
+    manifest["version"] = version
+
+    with open(
+        f"{os.getcwd()}/custom_components/frank_energie/manifest.json", "w"
+    ) as manifestfile:
+        manifestfile.write(json.dumps(manifest, indent=4, sort_keys=True))
+
+
+update_manifest()

--- a/.github/helpers/update_manifest.py
+++ b/.github/helpers/update_manifest.py
@@ -1,5 +1,7 @@
-"""Update the manifest file."""
-"""Idea from https://github.com/hacs/integration/blob/main/manage/update_manifest.py"""
+"""Update the manifest file.
+
+Sets the version number in the manifest file to the version number
+"""
 
 import sys
 import json
@@ -13,7 +15,9 @@ def update_manifest():
         if value in ["--version", "-V"]:
             version = sys.argv[index + 1]
 
-    with open(f"{os.getcwd()}/custom_components/frank_energie/manifest.json") as manifestfile:
+    with open(
+        f"{os.getcwd()}/custom_components/frank_energie/manifest.json"
+    ) as manifestfile:
         manifest = json.load(manifestfile)
 
     manifest["version"] = version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,47 @@
+# Combine files and upload it as zip to the release
+# Original file from https://github.com/hacs/integration/blob/main/.github/workflows/release.yml
+
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release_zip_file:
+    name: Prepare release asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.10
+
+      - name: "Set version number"
+        run: |
+          python3 ${{ github.workspace }}/.github/helpers/update_manifest.py --version ${GITHUB_REF##*/}
+
+      - name: Combine ZIP
+        run: |
+          cd ${{ github.workspace }}/custom_components/frank_energie
+          zip frank_energie.zip -r ./
+
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.3.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/custom_components/frank_energie/frank_energie.zip
+          asset_name: frank_energie.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: "Set version number"
         run: |

--- a/custom_components/frank_energie/manifest.json
+++ b/custom_components/frank_energie/manifest.json
@@ -9,5 +9,5 @@
   "requirements": [
     "python-frank-energie==3.1.0"
   ],
-  "version": "1.0.0"
+  "version": "0.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -4,5 +4,7 @@
 	"country": "NL",
 	"domains": "sensor",
 	"render_readme": true,
-	"homeassistant": "2022.3.0"
+	"homeassistant": "2022.3.0",
+	"zip_release": true,
+	"filename": "frank_energie.zip"
 }


### PR DESCRIPTION
`version` in manifest.json is niet bijgewerkt sinds versie 1.0.0. Dit maakt een .zip aan die door HACS gebruikt kan worden, in dit .zip is de juiste versienummer ingesteld.

Dit is niet _heel_ belangrijk, het wordt alleen gebruikt voor debugging aan onze kant als gebruikers issues hebben en bij statistics. Daarnaast worden 'versies' van componenten niet meer gebruikt in een officiële integratie (als we die stap maken).

Het installatie/update proces voor de gebruiker veranderd niet.