### PR TITLE
Use user-specific prices if authenticated

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -113,3 +113,4 @@ class FrankEnergieCoordinator(DataUpdateCoordinator):
                     user_prices.electricity = public_prices.electricity
 
                 return user_prices
+

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -113,4 +113,3 @@ class FrankEnergieCoordinator(DataUpdateCoordinator):
                     user_prices.electricity = public_prices.electricity
 
                 return user_prices
-

--- a/custom_components/frank_energie/manifest.json
+++ b/custom_components/frank_energie/manifest.json
@@ -7,7 +7,7 @@
   "issue_tracker": "https://github.com/bajansen/home-assistant-frank_energie/issues",
   "iot_class": "cloud_polling",
   "requirements": [
-    "python-frank-energie==4.0.3"
+    "python-frank-energie==4.1.0"
   ],
   "version": "0.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,3 @@
-
 {
 	"name": "Frank Energie",
 	"country": "NL",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest-homeassistant-custom-component~=0.13.7
 flake8~=5.0.4
 pytest~=7.2.1
-python-frank-energie~=3.1.0
+python-frank-energie~=4.1.0


### PR DESCRIPTION
Use user-specific prices if api is authenticated to allow getting prices including CO2 Compensation.