### PR TITLE
Fix tests are being skipped

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest-homeassistant-custom-component~=0.13.7
 flake8~=5.0.4
 pytest~=7.2.1
-python-frank-energie~=4.1.0
+pytest-asyncio~=0.20.3
+python-frank-energie~=5.0.1


### PR DESCRIPTION
Apparently, the tests never ran in CI..

```
tests/test_sensor.py ssss                                                [100%]

=============================== warnings summary ===============================
tests/test_sensor.py::test_sensors
tests/test_sensor.py::test_sensors_get_data_of_current_hour
tests/test_sensor.py::test_sensors_no_data_for_tomorrow
tests/test_sensor.py::test_sensors_hour_price_attr
  /opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/_pytest/python.py:184: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
  You need to install a suitable plugin for your async framework, for example:
    - anyio
    - pytest-asyncio
    - pytest-tornasync
    - pytest-trio
    - pytest-twisted
    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(nodeid)))
```

All tests are skipped without warning. by adding asyncio we enable them and see.. they fail! 